### PR TITLE
Remove gratuitous \newunit and \newunit\newblock

### DIFF
--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -167,7 +167,7 @@
     {\usebibmacro{unified:proc-as-article:maintitle}%
      \newunit\newblock}
   \usebibmacro{unified:proc-as-article:booktitle}%
-  \newunit}
+  \setunit{\addspace}}
 
 \renewbibmacro*{volume+number+eid}{%
   \printfield{volume}%
@@ -489,9 +489,8 @@
      \printfield{version}%
      \newunit\newblock
      \usebibmacro{unified:proc-as-article:maintitle+booktitle}%
-     \newunit\newblock%                          \newblock ensures period before pages
      \usebibmacro{unified:proc-as-article:volume+number+eid}
-     \newunit\newblock%
+     \newunit\newblock%                           \newblock ensures period before pages
      \usebibmacro{note+pages}%
      \newunit\newblock
      \iftoggle{bbx:isbn}


### PR DESCRIPTION
Bugs were introduced in cb3feb9389cb58e4b579048dd8125a192997babc and
86841da18af5ec38745b268f187e402e61102fcc where \newunit and
\newunit\newblock were being issued in places that they should not be
issued. \newunit inserts \newunitpunct into the punctuation
buffer (usually a period), but we do not want to have a period here
because conference proceedings with ISSNs ought to typeset as articles,
according to the Unified Style Sheet, and articles do not have periods
in between the journal title and the volume(number) information.

This commit fixes #6.
