### PR TITLE
Fixed a bug with \citeyear

### DIFF
--- a/cbx/sp-authoryear-comp.cbx
+++ b/cbx/sp-authoryear-comp.cbx
@@ -258,7 +258,7 @@
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \usebibmacro{prenote}}
-  {\printtext[bibhyperref]{\printfield{year}\printfield{extrayear}}}
+  {\printtext[bibhyperref]{\iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extrayear}}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
   

--- a/cbx/sp-authoryear-comp.cbx
+++ b/cbx/sp-authoryear-comp.cbx
@@ -266,21 +266,21 @@
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \usebibmacro{prenote}}
-  {\printtext[bibhyperref]{\printfield{year}\printfield{extrayear}}}
+  {\printtext[bibhyperref]{\iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extrayear}}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand{\posscitet}
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}}
-  {\printtext[bibhyperref]{\printnames{labelname}'s \printtext[parens]{\printfield{year}\printfield{extrayear}}}}
+  {\printtext[bibhyperref]{\printnames{labelname}'s \printtext[parens]{\iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extrayear}}}}
   {}
   {}
 
 \DeclareCiteCommand{\posscitealt}
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}}
-  {\printtext[bibhyperref]{\printnames{labelname}'s \printfield{year}\printfield{extrayear}}}
+  {\printtext[bibhyperref]{\printnames{labelname}'s \iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extrayear}}}
   {}
   {}
 


### PR DESCRIPTION
- in sp-authoryear-comp.cbx, added a conditional to catch entries without the year and print their labelyear; otherwise \pgcitet and the like don't print "n.d."
