### PR TITLE
Add `posscite` bibmacro based on original 'textcite'

### DIFF
--- a/cbx/sp-authoryear-comp.cbx
+++ b/cbx/sp-authoryear-comp.cbx
@@ -118,6 +118,59 @@
       {}%
     \multicitedelim}}
 
+\newbibmacro*{posscite}{% Based on textcite bib macro above
+  \iffieldequals{namehash}{\cbx@lasthash}
+    {\iffieldundef{shorthand}
+       {\usebibmacro{labelyearrepeat}}
+       {\setunit{\compcitedelim}%
+        \usebibmacro{cite:shorthand}%
+        \global\undef\cbx@lastyear}}
+    {\ifnameundef{labelname}
+       {\printtext[bibhyperref]{% Include labelname in hyperlink
+          \DeclareFieldAlias{bibhyperref}{default}% Prevent nested hyperlinks
+          \iffieldundef{shorthand}
+            {\usebibmacro{cite:label}%
+             \setunit{%
+               \global\booltrue{cbx:parens}%
+               \addspace\bibopenparen}%
+             \ifnumequal{\value{citecount}}{1}
+               {\usebibmacro{prenote}}
+               {}%
+             \usebibmacro{cite:labelyear+extrayear}}
+            {\usebibmacro{cite:shorthand}}%
+          \ifthenelse{\iffieldundef{postnote}\AND
+                      \(\value{multicitetotal}=0\AND\value{citetotal}=1\)}
+            {\bibcloseparen% Include closing parenthesis in hyperlink
+             \global\boolfalse{cbx:parens}}
+            {}}}
+       {\printtext[bibhyperref]{% Include labelname in hyperlink
+          \DeclareFieldAlias{bibhyperref}{default}% Prevent nested hyperlinks
+          \printnames{labelname}'s%
+          \setunit{%
+            \global\booltrue{cbx:parens}%
+            \addspace\bibopenparen}%
+          \ifnumequal{\value{citecount}}{1}
+            {\usebibmacro{prenote}}
+            {}%
+          \iffieldundef{shorthand}
+            {\iffieldundef{labelyear}
+               {\usebibmacro{cite:label}}
+               {\usebibmacro{cite:labelyear+extrayear}}%
+             \savefield{labelyear}{\cbx@lastyear}}
+            {\usebibmacro{cite:shorthand}%
+             \global\undef\cbx@lastyear}%
+          \ifthenelse{\iffieldundef{postnote}\AND
+                      \(\value{multicitetotal}=0\AND\value{citetotal}=1\)}
+            {\bibcloseparen% Include closing parenthesis in hyperlink
+             \global\boolfalse{cbx:parens}}
+            {}}%
+          \savefield{namehash}{\cbx@lasthash}}}%
+  \setunit{%
+    \ifbool{cbx:parens}
+      {\bibcloseparen\global\boolfalse{cbx:parens}}
+      {}%
+    \multicitedelim}}
+
 \newbibmacro*{cite:shorthand}{%
   \printtext[bibhyperref]{\printfield{shorthand}}}
 
@@ -270,11 +323,11 @@
   {\usebibmacro{postnote}}
 
 \DeclareCiteCommand{\posscitet}
-  {\boolfalse{citetracker}%
-   \boolfalse{pagetracker}}
-  {\printtext[bibhyperref]{\printnames{labelname}'s \printtext[parens]{\iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extrayear}}}}
+  {\usebibmacro{cite:init}}
+  {\usebibmacro{citeindex}%
+   \usebibmacro{posscite}}
   {}
-  {}
+  {\usebibmacro{textcite:postnote}}
 
 \DeclareCiteCommand{\posscitealt}
   {\boolfalse{citetracker}%


### PR DESCRIPTION
This is intended to address #18, but it's very copy-&-pastey just to add a "'s", so I'm wondering if there's a better solution.

`\posscitealt` would need a similar fix, but the changes here only fix `\posscitet`.
