### PR TITLE
labeldate backcompat

### DIFF
--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -10,6 +10,7 @@
 }
 {%
   \ExecuteBibliographyOptions{labeldate}
+  \def\printlabeldateextra{\printdateextralabel}
 }%
 
 \ExecuteBibliographyOptions{sorting=nyt,abbreviate,dateabbrev=false,useprefix=false}

--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -3,7 +3,16 @@
 % NB: The Unified Style Sheet wants abbreviated "ed(s)", "edn". But using the abbreviate option also abbreviates the names of months. But then dateabbrev=false restores the long names of months
 % biblatex has a "useprefix" option, which makes "von" count for alphabetization; the Unified Stylesheet does not want that, so it is important that this option be disabled (even if an author tries to set it to true)
 
-\ExecuteBibliographyOptions{labeldateparts,sorting=nyt,abbreviate,dateabbrev=false,useprefix=false}
+% For backward compatibility: as of biblatex 3.5 (2016/19/10), labeldateparts must be used instead of labeldate
+\@ifpackagelater{biblatex}{2016/09/09}
+{%
+  \ExecuteBibliographyOptions{labeldateparts}
+}
+{%
+  \ExecuteBibliographyOptions{labeldate}
+}%
+
+\ExecuteBibliographyOptions{sorting=nyt,abbreviate,dateabbrev=false,useprefix=false}
 
 % biblatex by default calls biblatex.def, we add to this authoryear.bbx, which in turn loads standard.bbx. So, sp-biblatex.bbx is built on top of those styles; once authoryear.bbx is loaded, we tell it not to put in dashes for repeated authors (in accordance with the Unified Stylesheet)
 

--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -6,7 +6,7 @@
 % For backward compatibility: choose labeldate or labeldateparts depending on the biblatex version 
 \@ifpackagelater{biblatex}{2016/09/09}
 {%
-  \ExecuteBibliographyOptions{labeldateparts} % as of biblatex 3.5 (2016/19/10)
+  \ExecuteBibliographyOptions{labeldateparts} % as of biblatex 3.5 (2016/09/10)
 }
 {%
   \ExecuteBibliographyOptions{labeldate}

--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -3,10 +3,10 @@
 % NB: The Unified Style Sheet wants abbreviated "ed(s)", "edn". But using the abbreviate option also abbreviates the names of months. But then dateabbrev=false restores the long names of months
 % biblatex has a "useprefix" option, which makes "von" count for alphabetization; the Unified Stylesheet does not want that, so it is important that this option be disabled (even if an author tries to set it to true)
 
-% For backward compatibility: as of biblatex 3.5 (2016/19/10), labeldateparts must be used instead of labeldate
+% For backward compatibility: choose labeldate or labeldateparts depending on the biblatex version 
 \@ifpackagelater{biblatex}{2016/09/09}
 {%
-  \ExecuteBibliographyOptions{labeldateparts}
+  \ExecuteBibliographyOptions{labeldateparts} % as of biblatex 3.5 (2016/19/10)
 }
 {%
   \ExecuteBibliographyOptions{labeldate}

--- a/cbx/sp-authoryear-comp.cbx
+++ b/cbx/sp-authoryear-comp.cbx
@@ -1,15 +1,16 @@
 \ProvidesFile{sp-authoryear-comp.cbx}
 
-% For backward compatibility: as of biblatex 3.5 (2016/19/10), labeldateparts must be used instead of labeldate
+% For backward compatibility: choose labeldate or labeldateparts depending on the biblatex version 
 \@ifpackagelater{biblatex}{2016/09/09}
 {%
-  \ExecuteBibliographyOptions{labeldateparts}
+  \ExecuteBibliographyOptions{labeldateparts} % as of biblatex 3.5 (2016/19/10)
 }
 {%
   \ExecuteBibliographyOptions{labeldate}
 }%
 
-\ExecuteBibliographyOptions{uniquename,uniquelist,autocite=inline}% disabled sortcites option, since it was sorting by name, instead of
+\ExecuteBibliographyOptions{uniquename,uniquelist,autocite=inline}
+% disabled sortcites option, since it was sorting by name, instead of
 % year, and we often want to keep citations in the order chosen by the
 % author
 \newbool{cbx:parens}

--- a/cbx/sp-authoryear-comp.cbx
+++ b/cbx/sp-authoryear-comp.cbx
@@ -1,7 +1,15 @@
 \ProvidesFile{sp-authoryear-comp.cbx}
 
-\ExecuteBibliographyOptions{labeldateparts,uniquename,uniquelist,autocite=inline}
-% disabled sortcites option, since it was sorting by name, instead of
+% For backward compatibility: as of biblatex 3.5 (2016/19/10), labeldateparts must be used instead of labeldate
+\@ifpackagelater{biblatex}{2016/09/09}
+{%
+  \ExecuteBibliographyOptions{labeldateparts}
+}
+{%
+  \ExecuteBibliographyOptions{labeldate}
+}%
+
+\ExecuteBibliographyOptions{uniquename,uniquelist,autocite=inline}% disabled sortcites option, since it was sorting by name, instead of
 % year, and we often want to keep citations in the order chosen by the
 % author
 \newbool{cbx:parens}

--- a/cbx/sp-authoryear-comp.cbx
+++ b/cbx/sp-authoryear-comp.cbx
@@ -3,7 +3,7 @@
 % For backward compatibility: choose labeldate or labeldateparts depending on the biblatex version 
 \@ifpackagelater{biblatex}{2016/09/09}
 {%
-  \ExecuteBibliographyOptions{labeldateparts} % as of biblatex 3.5 (2016/19/10)
+  \ExecuteBibliographyOptions{labeldateparts} % as of biblatex 3.5 (2016/09/10)
 }
 {%
   \ExecuteBibliographyOptions{labeldate}


### PR DESCRIPTION
Adds backward compatibility with `labeldate` option and helps to avoid annoying updates of biblatex.
Related to #23 and #25.  