### PR TITLE
Alias collection against book

### DIFF
--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -473,6 +473,9 @@
     {}%
   \usebibmacro{finentry}}
 
+% Aliased to ensure no period between the title and the series.
+\DeclareBibliographyAlias{collection}{book}
+
 \DeclareBibliographyAlias{incollection}{inproceedings}
 
 % Given the guidelines in the unified style sheet, we should print conference


### PR DESCRIPTION
Added an alias of `collection` against `book` to ensure that no period appeared between a title and a series declaration.