### PR TITLE
Add eprint support for LingBuzz and ROA

### DIFF
--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -389,6 +389,24 @@
 % in accordance with the unified style sheet guidelines
 \DeclareFieldFormat{volume:unified:proc-as-article}{#1}
 
+% Print LingBuzz entries using an eprint field
+\DeclareFieldFormat{eprint:lingbuzz}{%
+  LingBuzz\addcolon\space
+  \ifhyperref
+    {\href{http://ling.auf.net/lingbuzz/#1}{\nolinkurl{#1}}}
+    {\nolinkurl{#1}}
+}
+\DeclareFieldAlias{eprint:LingBuzz}{eprint:lingbuzz}
+
+% Print Rutgers Optimality Archive entries using an eprint field
+\DeclareFieldFormat{eprint:roa}{%
+  ROA\addcolon\space
+  \ifhyperref
+    {\href{http://roa.rutgers.edu/article/view/#1}{\nolinkurl{#1}}}
+    {\nolinkurl{#1}}
+}
+\DeclareFieldAlias{eprint:ROA}{eprint:roa}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % The bibliography drivers, specifying the formats of each type of entry in the bibliography
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -657,9 +657,7 @@
   \newunit\newblock
   \usebibmacro{location+date}%
   \newunit\newblock
-  \iftoggle{bbx:url}
-    {\usebibmacro{url+urldate}}
-    {}%
+  \usebibmacro{doi+eprint+url}%
   \newunit\newblock
   \usebibmacro{addendum+pubstate}%
   \setunit{\bibpagerefpunct}\newblock


### PR DESCRIPTION
Implements support with the `eprint` and `eprinttype` fields for the
LingBuzz and Rutgers Optimality Archive (ROA) repositories.