### PR TITLE
Replace extrayear with extradate

### DIFF
--- a/bbx/biblatex-sp-unified.bbx
+++ b/bbx/biblatex-sp-unified.bbx
@@ -95,7 +95,7 @@
 % Various bibmacros used in producing the bibliography
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\renewbibmacro*{date+extrayear}{%
+\renewbibmacro*{date+extradate}{%
   \iffieldundef{labelyear}
     {}
     {\printtext{\printlabeldateextra}}}%     Took out the parentheses around the year
@@ -120,7 +120,7 @@
     {\global\undef\bbx@lasthash
      \usebibmacro{labeltitle}%
      \newunit}%                               period instead of space
-  \usebibmacro{date+extrayear}}
+  \usebibmacro{date+extradate}}
 
 \renewbibmacro*{editor}{%
   \usebibmacro{bbx:editor}{editorstrg}}
@@ -143,7 +143,7 @@
     {\global\undef\bbx@lasthash
      \usebibmacro{labeltitle}%
      \newunit}%                                         period instead of space
-  \usebibmacro{date+extrayear}}
+  \usebibmacro{date+extradate}}
 
 \renewbibmacro*{translator}{%
   \usebibmacro{bbx:translator}{translatorstrg}}
@@ -166,7 +166,7 @@
     {\global\undef\bbx@lasthash
      \usebibmacro{labeltitle}%
      \newunit}%                                     period instead of space
-  \usebibmacro{date+extrayear}}
+  \usebibmacro{date+extradate}}
 
 \renewbibmacro*{journal}{%
   \iffieldundef{journaltitle}

--- a/cbx/sp-authoryear-comp.cbx
+++ b/cbx/sp-authoryear-comp.cbx
@@ -34,9 +34,9 @@
   \ifthenelse{\iffieldequals{labelyear}{\cbx@lastyear}\AND
               \(\value{multicitecount}=0\OR\iffieldundef{postnote}\)}
     {\setunit{\addcomma}%
-     \usebibmacro{cite:extrayear}}
+     \usebibmacro{cite:extradate}}
     {\setunit{\compcitedelim}%
-     \usebibmacro{cite:labelyear+extrayear}%
+     \usebibmacro{cite:labelyear+extradate}%
      \savefield{labelyear}{\cbx@lastyear}}}
 
 \newbibmacro*{cite}{% Based on cite bib macro from authoryear-comp.cbx
@@ -46,7 +46,7 @@
           \DeclareFieldAlias{bibhyperref}{default}% Prevent nested hyperlinks
           \usebibmacro{cite:label}%
           \setunit{\addspace}%
-          \usebibmacro{cite:labelyear+extrayear}}%
+          \usebibmacro{cite:labelyear+extradate}}%
           \usebibmacro{cite:reinit}}
        {\iffieldequals{namehash}{\cbx@lasthash}
           {\usebibmacro{labelyearrepeat}}
@@ -54,7 +54,7 @@
              \DeclareFieldAlias{bibhyperref}{default}% Prevent nested hyperlinks
              \printnames{labelname}%
              \setunit{\nameyeardelim}%
-             \usebibmacro{cite:labelyear+extrayear}}%
+             \usebibmacro{cite:labelyear+extradate}}%
              \savefield{namehash}{\cbx@lasthash}%
              \savefield{labelyear}{\cbx@lastyear}}}}
     {\usebibmacro{cite:shorthand}%
@@ -68,7 +68,7 @@
         \usebibmacro{cite:reinit}}
        {\iffieldequals{namehash}{\cbx@lasthash}
           {\usebibmacro{labelyearrepeat}}
-          {\usebibmacro{cite:labelyear+extrayear}%
+          {\usebibmacro{cite:labelyear+extradate}%
            \savefield{namehash}{\cbx@lasthash}%
            \savefield{labelyear}{\cbx@lastyear}}}}
     {\usebibmacro{cite:shorthand}%
@@ -93,7 +93,7 @@
              \ifnumequal{\value{citecount}}{1}
                {\usebibmacro{prenote}}
                {}%
-             \usebibmacro{cite:labelyear+extrayear}}
+             \usebibmacro{cite:labelyear+extradate}}
             {\usebibmacro{cite:shorthand}}%
           \ifthenelse{\iffieldundef{postnote}\AND
                       \(\value{multicitetotal}=0\AND\value{citetotal}=1\)}
@@ -112,7 +112,7 @@
           \iffieldundef{shorthand}
             {\iffieldundef{labelyear}
                {\usebibmacro{cite:label}}
-               {\usebibmacro{cite:labelyear+extrayear}}%
+               {\usebibmacro{cite:labelyear+extradate}}%
              \savefield{labelyear}{\cbx@lastyear}}
             {\usebibmacro{cite:shorthand}%
              \global\undef\cbx@lastyear}%
@@ -146,7 +146,7 @@
              \ifnumequal{\value{citecount}}{1}
                {\usebibmacro{prenote}}
                {}%
-             \usebibmacro{cite:labelyear+extrayear}}
+             \usebibmacro{cite:labelyear+extradate}}
             {\usebibmacro{cite:shorthand}}%
           \ifthenelse{\iffieldundef{postnote}\AND
                       \(\value{multicitetotal}=0\AND\value{citetotal}=1\)}
@@ -165,7 +165,7 @@
           \iffieldundef{shorthand}
             {\iffieldundef{labelyear}
                {\usebibmacro{cite:label}}
-               {\usebibmacro{cite:labelyear+extrayear}}%
+               {\usebibmacro{cite:labelyear+extradate}}%
              \savefield{labelyear}{\cbx@lastyear}}
             {\usebibmacro{cite:shorthand}%
              \global\undef\cbx@lastyear}%
@@ -189,17 +189,17 @@
     {\printtext[bibhyperref]{\printfield[citetitle]{labeltitle}}}
     {\printtext[bibhyperref]{\printfield{label}}}}
 
-\newbibmacro*{cite:labelyear+extrayear}{%
+\newbibmacro*{cite:labelyear+extradate}{%
   \iffieldundef{labelyear}
     {}
     {\printtext[bibhyperref]{%
        \printfield{labelyear}%
-       \printfield{extrayear}}}}
+       \printfield{extradate}}}}
 
-\newbibmacro*{cite:extrayear}{%
-  \iffieldundef{extrayear}
+\newbibmacro*{cite:extradate}{%
+  \iffieldundef{extradate}
     {}
-    {\printtext[bibhyperref]{\printfield{extrayear}}}}
+    {\printtext[bibhyperref]{\printfield{extradate}}}}
 
 \newbibmacro*{textcite:postnote}{%
   \usebibmacro{postnote}%
@@ -320,7 +320,7 @@
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \usebibmacro{prenote}}
-  {\printtext[bibhyperref]{\iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extrayear}}}
+  {\printtext[bibhyperref]{\iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extradate}}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
@@ -328,7 +328,7 @@
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}%
    \usebibmacro{prenote}}
-  {\printtext[bibhyperref]{\iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extrayear}}}
+  {\printtext[bibhyperref]{\iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extradate}}}
   {\multicitedelim}
   {\usebibmacro{postnote}}
 
@@ -342,7 +342,7 @@
 \DeclareCiteCommand{\posscitealt}
   {\boolfalse{citetracker}%
    \boolfalse{pagetracker}}
-  {\printtext[bibhyperref]{\printnames{labelname}'s \iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extrayear}}}
+  {\printtext[bibhyperref]{\printnames{labelname}'s \iffieldundef{year}{\printfield{labelyear}}{\printfield{year}}\printfield{extradate}}}
   {}
   {}
 


### PR DESCRIPTION
`biblatex` 3.8 deprecates `extrayear` in favour of `extradate`.

Closes #38.