### PR TITLE
Remove natbib-incompatible redefinitions

### DIFF
--- a/cbx/sp-authoryear-comp.cbx
+++ b/cbx/sp-authoryear-comp.cbx
@@ -288,19 +288,6 @@
 
 \renewcommand*{\nameyeardelim}{\addspace}
 
-\let\citealt\cite
-\let\citet\textcite
-\let\Citet\Textcite
-\newcommand{\pgcitep}[2]{(\cite{#1}:~#2)}
-\newcommand{\pgcitealt}[2]{\cite{#1}:~#2}
-\newcommand{\pgcitet}[2]{\citeauthor{#1} (\citeyear{#1}:~#2)}
-\newcommand{\pgposscitet}[2]{\citeauthor{#1}'s (\citeyear{#1}:~#2)}
-\newcommand{\seccitealt}[2]{\cite{#1}:~$\S$#2}
-\newcommand{\seccitep}[2]{(\cite{#1}:~$\S$#2)}
-\newcommand{\seccitet}[2]{\citeauthor{#1} (\citeyear{#1}:~$\S$#2)}
-\newcommand{\secposscitet}[2]{\citeauthor{#1}'s (\citeyear{#1}:~$\S$#2)}
-\let\citep\parencite
-
 \renewcommand*{\postnotedelim}{\addcolon\space}
 \DeclareFieldFormat{postnote}{#1}
 \DeclareFieldFormat{multipostnote}{#1}


### PR DESCRIPTION
The `\let` redefinitions broke biblatex's natbib compatibility mode.
These, and additional new commands have been removed.